### PR TITLE
Change AppComponent function name to be more appropriate.

### DIFF
--- a/src/app/components/app.component.ts
+++ b/src/app/components/app.component.ts
@@ -1,20 +1,18 @@
-import { Component } from '@angular/core';
-import { MetaService } from '../meta-service';
-import { NavResetService } from '../nav-reset.service';
+import { Component } from "@angular/core";
+import { NavResetService } from "../nav-reset.service";
 
 @Component({
-  selector: 'app-root',
-  templateUrl: '../templates/app.component.html',
-  styleUrls: ['../stylesheets/app.component.css',
-   '../stylesheets/shared/translucentBG.css'],
-  providers: [ MetaService ]
+  selector: "app-root",
+  templateUrl: "../templates/app.component.html",
+  styleUrls: ["../stylesheets/app.component.css",
+   "../stylesheets/shared/translucentBG.css"]
 })
 
 export class AppComponent {
 
   constructor(private service: NavResetService) {}
 
-  messageIn(): void {
+  messageToService(): void {
     this.service.relayNavMessage("reset");
   }
 

--- a/src/app/specs/app.component.spec.ts
+++ b/src/app/specs/app.component.spec.ts
@@ -37,7 +37,7 @@ describe("AppComponent", () => {
       DOMElement = fixture.nativeElement.children;
       fixture.detectChanges();
 
-      // find DebugElements with an attached RouterLinkStubDirective
+      // find DebugElements that have an attached RouterLinkStubDirective
       linkDes = fixture.debugElement
         .queryAll(By.directive(RouterLinkStubDirective));
 
@@ -66,7 +66,7 @@ describe("AppComponent", () => {
       it("should be called", ()=> {
         spy = spyOn(NavResetService.prototype, "relayNavMessage");
         expect(spy).not.toHaveBeenCalled();
-        comp.messageIn();
+        comp.messageToService();
         expect(spy).toHaveBeenCalled();
       });
 

--- a/src/app/templates/app.component.html
+++ b/src/app/templates/app.component.html
@@ -1,4 +1,4 @@
-<div id="header-parent" class="background" (click) = "messageIn()">
+<div id="header-parent" class="background" (click) = "messageToService()">
   <h1 [routerLink]="['/']"
 >META-HUMAN &nbsp;DATABASE
   </h1>

--- a/src/app/templates/metas.component.html
+++ b/src/app/templates/metas.component.html
@@ -23,5 +23,7 @@
       </li>
     </ul>
     <router-outlet></router-outlet>
+  <!-- When the selector with the routerlink binding is clicked the bound route
+   will appear here. -->
   </div>
 </div>


### PR DESCRIPTION
Replace quotation marks for uniformity.
Tidy specs.